### PR TITLE
Integration-Test use jogasaki in submodule

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -29,7 +29,6 @@ jobs:
       TG_PATH: itest/tg
       TG_IT_INSTALL_PATH: itest/dist
       TG_IT_RESULT_PATH: itest/result
-      TG_IT_JOGASAKI_PATH: itest/jogasaki
       TG_IT_TATEYAMA_BOOTSTRAP_PATH: .
       TG_IT_EISEN_PATH: itest/eisen
 
@@ -83,28 +82,9 @@ jobs:
           TGDIR: ${{ github.workspace }}/${{ env.TG_PATH }}
           TG_IT_RESULT_DIR: ${{ github.workspace }}/${{ env.TG_IT_RESULT_PATH }}
 
-      - id: Checkout_Jogasaki
-        name: Checkout_Jogasaki
-        uses: actions/checkout@v2
-        with:
-          repository: project-tsurugi/jogasaki
-          path: ${{ env.TG_IT_JOGASAKI_PATH }}
-          ref: master
-          submodules: recursive
-          token: ${{ secrets.GHA_PAT }}
-          clean: false
-
-      - id: Install_Jogasaki
-        name: Install_Jogasaki
-        run: ${{ env.TG_IT_EISEN_PATH }}/scripts/install-jogasaki.sh clean 2>&1 | tee ${TG_IT_RESULT_DIR}/install-jogasaki.log
-        env:
-          TG_IT_JOGASAKI_DIR: ${{ github.workspace }}/${{ env.TG_IT_JOGASAKI_PATH }}
-          TG_IT_INSTALL_DIR: ${{ github.workspace }}/${{ env.TG_IT_INSTALL_PATH }}
-          TG_IT_RESULT_DIR: ${{ github.workspace }}/${{ env.TG_IT_RESULT_PATH }}
-
       - id: Install_Tateyama_Bootstrap
         name: Install_Tateyama_Bootstrap
-        run: ${{ env.TG_IT_EISEN_PATH }}/scripts/install-tateyama-bootstrap.sh clean 2>&1 | tee ${TG_IT_RESULT_DIR}/install-tateyama-bootstrap.log
+        run: ${{ env.TG_IT_EISEN_PATH }}/scripts/install-tateyama-bootstrap.sh clean jogasaki ogawayama 2>&1 | tee ${TG_IT_RESULT_DIR}/install-tateyama-bootstrap.log
         env:
           TG_IT_TATEYAMA_BOOTSTRAP_DIR: ${{ github.workspace }}/${{ env.TG_IT_TATEYAMA_BOOTSTRAP_PATH }}
           TG_IT_INSTALL_DIR: ${{ github.workspace }}/${{ env.TG_IT_INSTALL_PATH }}


### PR DESCRIPTION
tateyama-bootstrapのIntegration-Testでは、jogasakiをsubmoduleのコミットを使うよう変更します。
tateyama-bootstrapのsubmodule更新忘れが多く、このコミットを使うテストが必要と判断したため。