### PR TITLE
handle errors in starting framework

### DIFF
--- a/src/tateyama/server/backend.cpp
+++ b/src/tateyama/server/backend.cpp
@@ -119,7 +119,11 @@ int backend_main(int argc, char **argv) {
     // status_info
     auto status_info = sv.find_resource<tateyama::status_info::resource::bridge>();
 
-    sv.setup();
+    if(! sv.setup()) {
+        // detailed message must have been logged in the components where setup error occurs
+        LOG(ERROR) << "Starting server failed due to errors in setting up server application framework.";
+        exit(1);
+    }
     auto* db = sqlsvc->database();
     if (tpcc_mode) {
         db->config()->prepare_benchmark_tables(true);
@@ -129,7 +133,11 @@ int backend_main(int argc, char **argv) {
     }
     status_info->whole(tateyama::status_info::state::ready);
 
-    sv.start();
+    if(! sv.start()) {
+        // detailed message must have been logged in the components where start error occurs
+        LOG(ERROR) << "Starting server failed due to errors in starting server application framework.";
+        exit(1);
+    }
     status_info->whole(tateyama::status_info::state::activated);
     LOG(INFO) << "database started";
 


### PR DESCRIPTION
https://github.com/project-tsurugi/tateyama/pull/63 の導入後に導入予定の変更です。framework::serverの失敗通知を受けてサーバー起動を終了するようにします。