### PR TITLE
SIGSEGVでスタックトレースをダンプするためのハンドラ追加

### DIFF
--- a/src/tateyama/server/backend.cpp
+++ b/src/tateyama/server/backend.cpp
@@ -64,6 +64,7 @@ struct endpoint_context {
 
 int backend_main(int argc, char **argv) {
     google::InitGoogleLogging("tateyama_database_server");
+    google::InstallFailureSignalHandler();
 
     // command arguments
     gflags::SetUsageMessage("tateyama database server");


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/157 で報告のように、tateyama-serverがSEGVなどのシグナルでクラッシュした際、シグナルハンドラが設定されていないために何も出力されず、syslogに数行のログが書かれるだけになる。
glogのシグナルハンドラを使ってスタックトレースを出力するようにする。