### PR TITLE
Workaround for protobuf Issue 7140 (gcc warns generated code)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ set_source_files_properties(
         ${GENERATED_PROTO_SRCS}
         PROPERTIES
         GENERATED TRUE
-        COMPILE_FLAGS -Wno-unused-parameter
+        COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds"
         )
 
 add_executable(oltp


### PR DESCRIPTION
protobuf (< 3.14) が g++ でコンパイルすると警告が出るコードを生成する問題があるため、それの対応です。

本来 -Warray-bounds オプションは `-O3` 等でしか有効にならないため、顕在化していなかったのですが、条件がよくわからないのですが `-O2` でもこの警告が出ることがあるようです。(Tsurugi のビルドで `-Werror` を付けているため、警告が出るとビルド失敗となる)

* 最近 Ubuntu 22.04 LTS でこの問題に当たっていました。
* GitHub の protobuf の Issue 7140 がその問題なのですが、直接リンクすると、Issue のページから逆リンクされるかもしれないので、リンクしないようにしています。
