### PR TITLE
Stop using MD5 functions of openssl (for FTBFS with OpenSSL 3.0)

### DIFF
--- a/src/tateyama/configuration/configuration.h
+++ b/src/tateyama/configuration/configuration.h
@@ -18,9 +18,10 @@
 #include <string_view>
 #include <cstdlib>
 #include <exception>
+#include <iomanip>
+#include <sstream>
 
 #include <boost/filesystem/path.hpp>
-#include <openssl/md5.h>
 
 #include <tateyama/api/configuration.h>
 
@@ -103,29 +104,11 @@ private:
         valid_ = true;
     }
     std::string digest(const std::string& path_string) {
-        MD5_CTX mdContext;
-        unsigned int len = path_string.length();
-        std::array<unsigned char, MD5_DIGEST_LENGTH> digest{};
-
-        std::string s{};
-        s.resize(len + 1);
-        path_string.copy(s.data(), len + 1);
-        s.at(len) = '\0';
-        MD5_Init(&mdContext);
-        MD5_Update (&mdContext, s.data(), len);
-        MD5_Final(digest.data(), &mdContext);
-
-        std::string digest_string{};
-        digest_string.resize(MD5_DIGEST_LENGTH * 2);
-        auto it = digest_string.begin();
-        for(unsigned char c : digest) {
-            std::uint32_t n = c & 0xf0U;
-            n >>= 8U;
-            *(it++) = (n < 0xa) ? ('0' + n) : ('a' + (n - 0xa));
-            n = c & 0xfU;
-            *(it++) = (n < 0xa) ? ('0' + n) : ('a' + (n - 0xa));
-        }
-        return digest_string;
+        std::size_t hash = std::hash<std::string>{}(path_string);
+        std::ostringstream sstream;
+        sstream << std::hex << std::setfill('0')
+                << std::setw(sizeof(hash) * 2) << hash;
+        return sstream.str();
     }
 };
 

--- a/src/tateyama/configuration/configuration.h
+++ b/src/tateyama/configuration/configuration.h
@@ -104,7 +104,7 @@ private:
         valid_ = true;
     }
     std::string digest(const std::string& path_string) {
-        std::size_t hash = std::hash<std::string>{}(path_string);
+        auto hash = std::hash<std::string>{}(path_string);
         std::ostringstream sstream;
         sstream << std::hex << std::setfill('0')
                 << std::setw(sizeof(hash) * 2) << hash;


### PR DESCRIPTION
https://github.com/project-tsurugi/tateyama/pull/105 の続きで、 tateyama-bootstrap 側の対応です。
