### PR TITLE
add datastore.recover_max_parallelism config

### DIFF
--- a/src/tateyama/configuration/bootstrap_configuration.cpp
+++ b/src/tateyama/configuration/bootstrap_configuration.cpp
@@ -52,6 +52,7 @@ static constexpr std::string_view default_configuration {  // NOLINT
     "[datastore]\n"
         "log_location=\n"
         "logging_max_parallelism=112\n"
+        "recover_max_parallelism=8\n"
 
     "[cc]\n"
         "epoch_duration=40000\n"


### PR DESCRIPTION
project-tsurugi/tsurugi-issues#289 の対応で
構成ファイルの [datastore] セクションに recover_max_parallelism 項目を追加する変更です。