### PR TITLE
explicitly discarding return value of release_FOO (for FTBFS with protobuf v3.17.0)

### DIFF
--- a/src/tateyama/transport/transport.h
+++ b/src/tateyama/transport/transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Project Tsurugi.
+ * Copyright 2022-2024 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,12 +183,12 @@ private:
         tateyama::proto::endpoint::request::Request request{};
         request.set_allocated_handshake(&handshake);
         auto response = send<tateyama::proto::endpoint::response::Handshake>(request);
-        request.release_handshake();
+        (void)request.release_handshake();
 
-        wire_information.release_ipc_information();
-        handshake.release_wire_information();
+        (void)wire_information.release_ipc_information();
+        (void)handshake.release_wire_information();
 
-        handshake.release_client_information();
+        (void)handshake.release_client_information();
         return response;
     }
 };


### PR DESCRIPTION
protobuf の新しいバージョンで、生成されるコードの `release_ナントカ` 関数に `[[nodiscard]]` がつくようになったため、コンパイル時に警告が出るようになりました。
加えて tateyama-bootstrap は `-Werror` しているためビルドが失敗してしまうため、その対応になります。

目視で確認し、`set_allocated_ナントカ` で設定したものであるため返値を捨てても問題なさそうであることを確認しました。