### PR TITLE
build: make RPATH relative

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -104,7 +104,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -124,7 +124,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -134,7 +134,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -164,7 +164,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -174,7 +174,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -194,7 +194,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -204,7 +204,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -214,6 +214,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_BRIDGE_ONLY=ON -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DFORCE_INSTALL_RPATH=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=${{ inputs.sharksfin-implementation }} -DBUILD_BRIDGE_ONLY=ON -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,6 +34,21 @@ jobs:
         with:
           sharksfin-implementation: shirakami
 
+      - name: Install_mpdecimal
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          mkdir build-mpdecimal
+          cd build-mpdecimal
+          curl -OL https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz
+          tar xf mpdecimal-2.5.1.tar.gz
+          cd mpdecimal-2.5.1
+          ./configure --prefix="${GITHUB_WORKSPACE}/.local"
+          make -j8
+          make install
+          cd ../..
+          rm -fr build-mpdecimal;
+        shell: bash
+
       - name: CMake_Install
         run: |
           rm -rf build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=shirakami -DOGAWAYAMA=ON -DFORCE_INSTALL_RPATH=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DSHARKSFIN_IMPLEMENTATION=shirakami -DOGAWAYAMA=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
           cmake --build . --target install --clean-first
 
       - name: CTest

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ available options:
 * `-DCMAKE_INSTALL_PREFIX=<installation directory>` - change install location
 * `-DCMAKE_PREFIX_PATH=<installation directory>` - indicate prerequisite installation directory
 * `-DCMAKE_IGNORE_PATH="/usr/local/include;/usr/local/lib/"` - specify the libraries search paths to ignore. This is convenient if the environment has conflicting version installed on system default search paths. (e.g. gflags in /usr/local)
-* `-DFORCE_INSTALL_RPATH=ON` - automatically configure `INSTALL_RPATH` for non-default library paths
 * `-DSHARKSFIN_IMPLEMENTATION=<implementation name>` - switch sharksfin implementation. Available options are `memory` and `shirakami` (default: `memory`)
 * `-DOGAWAYAMA=ON` - enable ogawayama bridge
 * `-DENABLE_JEMALLOC` - use jemalloc instead of default `malloc`
@@ -60,8 +59,8 @@ available options:
   * `-DENABLE_SANITIZER=OFF` - disable sanitizers (requires `-DCMAKE_BUILD_TYPE=Debug`)
   * `-DENABLE_UB_SANITIZER=ON` - enable undefined behavior sanitizer (requires `-DENABLE_SANITIZER=ON`)
   * `-DENABLE_COVERAGE=ON` - enable code coverage analysis (requires `-DCMAKE_BUILD_TYPE=Debug`)
-    
-### install 
+
+### install
 
 ```sh
 cmake --build . --target install
@@ -74,7 +73,7 @@ Execute the test as below:
 ctest -V
 ```
 
-### Customize logging setting 
+### Customize logging setting
 You can customize logging in the same way as sharksfin. See sharksfin [README.md](https://github.com/project-tsurugi/sharksfin/blob/master/README.md#customize-logging-setting) for more details.
 
 ```sh

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -1,35 +1,4 @@
 function(install_common target_name export_name)
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,8 @@ add_executable(server
 
 set_target_properties(server
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "tsurugidb"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "tsurugidb"
         )
 
 target_include_directories(server
@@ -132,7 +133,8 @@ add_dependencies(tgctl
 
 set_target_properties(tgctl
         PROPERTIES
-        RUNTIME_OUTPUT_NAME "tgctl"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                RUNTIME_OUTPUT_NAME "tgctl"
         )
 
 target_include_directories(tgctl


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.

note:
After this change, ctest in CI failed with following error only on ubuntu-24.04 .

```
/__w/tateyama-bootstrap/tateyama-bootstrap/build/test/tateyama-bootstrap-test: error while loading shared libraries: libmpdec++.so.3: cannot open shared object file: No such file or directory
```

The mpdecimal on ci environment was installed to default location ( `/usr/local/bin` ), not lib, so install mpdec in install path in CI worfklow on the following commit
- 91f5e5b8eba2bfa25fea9809de36f75e495b6a6e
