### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(server
 
 set_target_properties(server
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                 RUNTIME_OUTPUT_NAME "tsurugidb"
         )
 
@@ -150,7 +150,6 @@ add_dependencies(tgctl
 
 set_target_properties(tgctl
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
                 RUNTIME_OUTPUT_NAME "tgctl"
         )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、起動時にファイルを見つけられず問題となります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。
また、もともと `bin/tgctl` にも RPATH を設定していますが、 `bin/tgctl` は libdir の .so ファイルを参照しないので、この設定部分は変更ではなく削除します。