### PR TITLE
add system.instance_id to configuration

### DIFF
--- a/src/tateyama/configuration/bootstrap_configuration.cpp
+++ b/src/tateyama/configuration/bootstrap_configuration.cpp
@@ -96,6 +96,7 @@ static constexpr std::string_view default_configuration {  // NOLINT
 
     "[system]\n"
         "pid_directory=/var/lock\n"
+        "instance_id=\n"  // update to default value later
 
     "[authentication]\n"
         "enabled=false\n"

--- a/src/tateyama/configuration/bootstrap_configuration.h
+++ b/src/tateyama/configuration/bootstrap_configuration.h
@@ -46,7 +46,7 @@ public:
         }
     }
     std::shared_ptr<tateyama::api::configuration::whole> get_configuration() {
-        inctance_id_handler::setup(configuration_.get());
+        instance_id_handler::setup(configuration_.get());
         return configuration_;
     }
     [[nodiscard]] std::filesystem::path lock_file() const {

--- a/src/tateyama/configuration/bootstrap_configuration.h
+++ b/src/tateyama/configuration/bootstrap_configuration.h
@@ -26,6 +26,7 @@
 
 #include "tateyama/tgctl/tgctl.h"
 #include "tateyama/tgctl/runtime_error.h"
+#include "instance_id_helper.h"
 
 namespace tateyama::configuration {
 
@@ -45,6 +46,7 @@ public:
         }
     }
     std::shared_ptr<tateyama::api::configuration::whole> get_configuration() {
+        inctance_id_handler::setup(configuration_.get());
         return configuration_;
     }
     [[nodiscard]] std::filesystem::path lock_file() const {

--- a/src/tateyama/configuration/instance_id_helper.h
+++ b/src/tateyama/configuration/instance_id_helper.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018-2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <unistd.h>
+#include <exception>
+
+#include <tateyama/api/configuration.h>
+
+class inctance_id_handler {
+    static constexpr std::size_t MAX_INSTANCE_ID_LENGTH = 63;
+
+public:
+    static void setup(tateyama::api::configuration::whole* conf) {
+        auto* section = conf->get_section("system");
+        if (auto instance_id_opt = section->get<std::string>("instance_id"); instance_id_opt) {
+            section->set("instance_id", instance_id(instance_id_opt.value()));
+        } else {
+            throw std::runtime_error("instance_id is not given in tsurugi.ini");
+        }
+    }
+
+private:
+    static std::string instance_id(std::string_view id) {
+        using namespace std::literals::string_literals;
+        
+        if (id.empty()) {
+            std::array<char, MAX_INSTANCE_ID_LENGTH> hostname{};
+            if (gethostname(hostname.data(), MAX_INSTANCE_ID_LENGTH) == 0) {
+                std::string instance_id{hostname.data(), strlen(hostname.data())};
+                try {
+                    tolower_and_check(instance_id);
+                    return instance_id;
+                } catch (std::runtime_error &ex) {
+                    return "localhost"s;
+                }
+            }
+            return "localhost"s;
+        }
+        std::string instance_id{id};
+        tolower_and_check(instance_id);
+        return instance_id;
+    }
+
+    static void tolower_and_check(std::string& s) {
+        if (s.empty()) {
+            throw std::runtime_error("instance_id given is empty string");
+        }
+        if (s.length() > MAX_INSTANCE_ID_LENGTH) {
+            throw std::runtime_error("instance_id is too long");
+        }
+        if (s.at(0) == '-') {
+            throw std::runtime_error("instance_id begins with hyphen");
+        }
+        if (s.at(s.length() - 1) == '-') {
+            throw std::runtime_error("instance_id ends with hyphen");
+        }
+        std::transform(
+            s.begin(), 
+            s.end(), 
+            s.begin(),
+            [](char c) { return std::tolower(c); }
+        );
+        bool hyphen{false};
+        for(auto c: s) {
+            if (('a' <= c && c <= 'z') ||
+                ('0' <= c && c <= '9')) {
+                hyphen = false;
+                continue;
+            }
+            if ('-' == c) {
+                if (hyphen) {
+                    throw std::runtime_error("instance_id has consecutive hyphens");
+                }
+                hyphen = true;
+                continue;
+            }
+            throw std::runtime_error("instance_id has illegal charactor");
+        }
+    }
+};

--- a/src/tateyama/configuration/instance_id_helper.h
+++ b/src/tateyama/configuration/instance_id_helper.h
@@ -24,7 +24,7 @@
 
 #include <tateyama/api/configuration.h>
 
-class inctance_id_handler {
+class instance_id_handler {
     static constexpr std::size_t MAX_INSTANCE_ID_LENGTH = 63;
 
 public:
@@ -92,7 +92,7 @@ private:
                 hyphen = true;
                 continue;
             }
-            throw std::runtime_error("instance_id has illegal charactor");
+            throw std::runtime_error("instance_id has illegal character");
         }
     }
 };

--- a/src/tateyama/server/backend.cpp
+++ b/src/tateyama/server/backend.cpp
@@ -90,12 +90,18 @@ static int backend_main(int argc, char **argv) {
         LOG(ERROR) << "error in create_bootstrap_configuration";
         exit(1);
     }
-    auto conf = bst_conf.get_configuration();
-    if (conf == nullptr) {
-        LOG(ERROR) << "error in create_configuration";
+    std::shared_ptr<tateyama::api::configuration::whole> conf{};
+    try {
+        conf = bst_conf.get_configuration();
+        if (conf == nullptr) {
+            LOG(ERROR) << "error in create_configuration";
+            exit(1);
+        }
+        setup_glog(conf.get());
+    } catch (std::runtime_error& e) {
+        LOG(ERROR) << e.what();
         exit(1);
     }
-    setup_glog(conf.get());
 #ifdef ENABLE_ALTIMETER
     auto altimeter_object = std::make_unique<tateyama::altimeter::altimeter_helper>(conf.get());
     bool altimeter_wellness = true;

--- a/test/tateyama/configuration/bootstrap_configuration_test.cpp
+++ b/test/tateyama/configuration/bootstrap_configuration_test.cpp
@@ -23,7 +23,7 @@ namespace tateyama::testing {
 class bootstrap_configuration_test : public ::testing::Test {
 public:
     virtual void SetUp() {
-        helper_ = std::make_unique<directory_helper>("bootstrap_configuration_test/var/etc", 20200, true);
+        helper_ = std::make_unique<directory_helper>("bootstrap_configuration_test/var/etc", 20500, true);
         helper_->set_up();
         std::cout << helper_->conf_file_path() << std::endl;
     }

--- a/test/tateyama/configuration/config_test.cpp
+++ b/test/tateyama/configuration/config_test.cpp
@@ -33,7 +33,7 @@ namespace tateyama::configuration {
 class config_test : public ::testing::Test {
 public:
     virtual void SetUp() {
-        helper_ = std::make_unique<directory_helper>("config_test", 20201);
+        helper_ = std::make_unique<directory_helper>("config_test", 20501);
         helper_->set_up("[system]\n    pid_directory=/pid_directory-for-test\n");
     }
     virtual void TearDown() {

--- a/test/tateyama/configuration/instance_id_test.cpp
+++ b/test/tateyama/configuration/instance_id_test.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-2026 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_root.h"
+
+#include <string>
+
+#include "tateyama/configuration/bootstrap_configuration.h"
+
+namespace tateyama::configuration {
+
+class instance_id_test : public ::testing::Test {
+public:
+    virtual void SetUp() {
+        helper_ = std::make_unique<directory_helper>("instance_id_test", 20511);
+    }
+    virtual void TearDown() {
+        helper_->tear_down();
+    }
+
+protected:
+    std::unique_ptr<directory_helper> helper_{};
+};
+
+TEST_F(instance_id_test, normal) {
+    helper_->set_up("[system]\n    instance_id=instance-id-for-test\n");
+    auto conf = tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration();
+
+    auto* section = conf->get_section("system");
+    if (auto instance_id_opt = section->get<std::string>("instance_id"); instance_id_opt) {
+        EXPECT_EQ("instance-id-for-test", instance_id_opt.value());
+    } else {
+        throw std::runtime_error("instance_id is not given in tsurugi.ini");
+    }
+}
+
+TEST_F(instance_id_test, upper_case) {
+    helper_->set_up("[system]\n    instance_id=INSTANCE-ID-FOR-TEST\n");
+    auto conf = tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration();
+
+    auto* section = conf->get_section("system");
+    if (auto instance_id_opt = section->get<std::string>("instance_id"); instance_id_opt) {
+        EXPECT_EQ("instance-id-for-test", instance_id_opt.value());
+    } else {
+        throw std::runtime_error("instance_id is not given in tsurugi.ini");
+    }
+}
+
+TEST_F(instance_id_test, empty) {
+    helper_->set_up();
+    auto conf = tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration();
+
+    auto* section = conf->get_section("system");
+    if (auto instance_id_opt = section->get<std::string>("instance_id"); instance_id_opt) {
+        static constexpr std::size_t MAX_INSTANCE_ID_LENGTH = 63;
+        std::array<char, MAX_INSTANCE_ID_LENGTH> hostname{};
+        if (gethostname(hostname.data(), MAX_INSTANCE_ID_LENGTH) != 0) {
+            FAIL();
+        }
+        EXPECT_EQ(hostname.data(), instance_id_opt.value());
+    } else {
+        FAIL();
+    }
+}
+
+TEST_F(instance_id_test, begins_with_hyphon) {
+    helper_->set_up("[system]\n    instance_id=-instance-id-for-test\n");
+    EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
+}
+
+TEST_F(instance_id_test, ends_with_hyphon) {
+    helper_->set_up("[system]\n    instance_id=instance-id-for-test-\n");
+    EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
+}
+
+TEST_F(instance_id_test, double_hyphon) {
+    helper_->set_up("[system]\n    instance_id=instance-id--for-test-\n");
+    EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
+}
+
+TEST_F(instance_id_test, illegal_char) {
+    helper_->set_up("[system]\n    instance_id=instance_id_for_test\n");
+    EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
+}
+
+TEST_F(instance_id_test, within_length_limit) {
+    helper_->set_up("[system]\n    instance_id=instance-id2345678921234567893123456789412345678951234567896123\n");
+    EXPECT_NO_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration());
+}
+
+TEST_F(instance_id_test, over_length_limit) {
+    helper_->set_up("[system]\n    instance_id=instance-id23456789212345678931234567894123456789512345678961234\n");
+    EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
+}
+
+}  // namespace tateyama::configuration

--- a/test/tateyama/configuration/instance_id_test.cpp
+++ b/test/tateyama/configuration/instance_id_test.cpp
@@ -76,18 +76,18 @@ TEST_F(instance_id_test, empty) {
     }
 }
 
-TEST_F(instance_id_test, begins_with_hyphon) {
+TEST_F(instance_id_test, begins_with_hyphen) {
     helper_->set_up("[system]\n    instance_id=-instance-id-for-test\n");
     EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
 }
 
-TEST_F(instance_id_test, ends_with_hyphon) {
+TEST_F(instance_id_test, ends_with_hyphen) {
     helper_->set_up("[system]\n    instance_id=instance-id-for-test-\n");
     EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
 }
 
-TEST_F(instance_id_test, double_hyphon) {
-    helper_->set_up("[system]\n    instance_id=instance-id--for-test-\n");
+TEST_F(instance_id_test, double_hyphen) {
+    helper_->set_up("[system]\n    instance_id=instance-id--for-test\n");
     EXPECT_THROW(tateyama::configuration::bootstrap_configuration::create_bootstrap_configuration(helper_->conf_file_path()).get_configuration(), std::runtime_error);
 }
 


### PR DESCRIPTION
This PR adds support for the `system.instance_id` configuration parameter to allow users to specify a custom instance identifier for the Tsurugi database system. If not specified, the system defaults to using the hostname (or "localhost" if the hostname is invalid).

**Changes:**
- Added instance_id validation and normalization logic with length limits (max 63 characters) and character restrictions (lowercase alphanumeric and hyphens, with specific hyphen placement rules)
- Added comprehensive test coverage for instance_id validation including normal cases, edge cases, and error conditions
- Enhanced error handling in backend initialization to catch configuration validation errors

https://github.com/project-tsurugi/tsurugi-issues/issues/1409