### PR TITLE
add grpc_server.fullchain_crt and grpc_server.server_key parameters t…

### DIFF
--- a/src/tateyama/configuration/bootstrap_configuration.cpp
+++ b/src/tateyama/configuration/bootstrap_configuration.cpp
@@ -109,6 +109,8 @@ static constexpr std::string_view default_configuration {  // NOLINT
         "listen_address=0.0.0.0:52345\n"
         "endpoint=dns:///localhost:52345\n"
         "secure=false\n"
+        "fullchain_crt=\n"
+        "server_key=\n"
 
     "[blob_relay]\n"
         "enabled=true\n"


### PR DESCRIPTION
Adds new gRPC server TLS-related configuration keys to the built-in default configuration template (used when generating/bootstrapping `tsurugi.ini`), aligning with the request in project-tsurugi/tsurugi-issues#1400.

**Changes:**
- Add `grpc_server.fullchain_crt` default entry (empty value) to the default configuration template.
- Add `grpc_server.server_key` default entry (empty value) to the default configuration template.