### PR TITLE
feat(server): integrate graph-service into tsurugidb server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(jogasaki_engine "${jogasaki_package}-engine")
 
 find_package(${tateyama_package} REQUIRED)
 find_package(${jogasaki_package} REQUIRED)
+find_package(graph-service REQUIRED)
 find_package(takatori REQUIRED)
 find_package(yugawara REQUIRED)
 find_package(sharksfin REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(server
         PRIVATE api
         PRIVATE ${jogasaki_engine}
         PRIVATE ${tateyama_engine}
+        PRIVATE graph-service
         PRIVATE takatori
         PRIVATE yugawara
         PRIVATE glog::glog

--- a/src/tateyama/server/backend.cpp
+++ b/src/tateyama/server/backend.cpp
@@ -36,6 +36,8 @@
 
 #include <jogasaki/api/kvsservice/service.h>
 #include <jogasaki/api/kvsservice/resource.h>
+#include <tateyama/framework/graph/service.h>
+#include <tateyama/framework/graph/resource.h>
 #include <jogasaki/api.h>
 
 #include "tateyama/process/proc_mutex.h"
@@ -165,6 +167,9 @@ static int backend_main(int argc, char **argv) {
 
     tgsv.add_resource(std::make_shared<jogasaki::api::kvsservice::resource>());
     tgsv.add_service(std::make_shared<jogasaki::api::kvsservice::service>());
+
+    tgsv.add_resource(std::make_shared<tateyama::framework::graph::resource>());
+    tgsv.add_service(std::make_shared<tateyama::framework::graph::service>());
 
     // status_info
     auto status_info = tgsv.find_resource<tateyama::status_info::resource::bridge>();


### PR DESCRIPTION
## Summary
- Add graph-service component to the tsurugidb server bootstrap
- Register graph-service as a tateyama service (ID 13) and resource (ID 14)

## Changes
- Server bootstrap configuration to load graph-service on startup

## Test plan
- [ ] Server starts successfully with graph-service enabled
- [ ] Graph-service responds to Cypher queries via tateyama protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)