### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,7 +20,7 @@ runs:
 
   steps:
     - name: Checkout_Takatori
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/takatori
@@ -28,7 +28,7 @@ runs:
         ref: master
 
     - name: Checkout_Yugawara
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/yugawara
@@ -37,7 +37,7 @@ runs:
         submodules: true
 
     - name: Checkout_Mizugaki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/mizugaki
@@ -45,7 +45,7 @@ runs:
         ref: master
 
     - name: Checkout_Limestone
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/limestone
@@ -53,7 +53,7 @@ runs:
         ref: master
 
     - name: Checkout_Yakushima
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/yakushima
@@ -61,7 +61,7 @@ runs:
         ref: master
 
     - name: Checkout_Shirakami
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/shirakami
@@ -69,7 +69,7 @@ runs:
         ref: master
 
     - name: Checkout_Sharksfin
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/sharksfin
@@ -77,7 +77,7 @@ runs:
         ref: master
 
     - name: Checkout_Data_Relay_gRPC
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/data-relay-grpc
@@ -85,7 +85,7 @@ runs:
         ref: master
 
     - name: Checkout_Tateyama
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/tateyama
@@ -94,7 +94,7 @@ runs:
         submodules: true
 
     - name: Checkout_Jogasaki
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.checkout == 'true' }}
       with:
         repository: project-tsurugi/jogasaki

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -79,7 +79,7 @@ jobs:
           ctest --verbose
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
 
   Analysis:
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -138,5 +138,5 @@ jobs:
           ninja doxygen 2> >(tee doxygen-error.log)
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/